### PR TITLE
Made unify's enter/exit functions more usable

### DIFF
--- a/src/coffee/Singult.coffee
+++ b/src/coffee/Singult.coffee
@@ -213,12 +213,10 @@ singult.coffee.Ignore = -> return this
 #Unifies $nodes with data and mapping contained in u.
 singult.coffee.unify_ = ($container, u) ->
   enter = u.enter or (d) ->
-    $el = singult.coffee.render singult.coffee.canonicalize u.mapping d
-    $container.appendChild $el
-    return $el
+    return singult.coffee.render singult.coffee.canonicalize u.mapping d
   update = u.update or ($n, d) ->
     return singult.coffee.merge $n, singult.coffee.canonicalize u.mapping d
-  exit = u.exit or ($n) -> $container.removeChild $n
+  exit = u.exit
   key_fn = u.key_fn or (d, idx) -> idx
 
   $nodes = $container.childNodes
@@ -267,19 +265,22 @@ singult.coffee.unify_ = ($container, u) ->
 
   #iterate: d,i in u.data, for each d,i:
   u.data.forEach (d, i) ->
-    # after each step of the forEach, the element at $nodes[i] is
+    # after each step of the forEach, the element at $nodes[i]
     # matches the input data of d.
     $n = if i < $nodes.length then $nodes[i]
     n_key = if $n then node_to_key $n, i
     d_key = data_to_key d, i
     if !$n?
       $el = enter d
+      $container.appendChild $el
       singult.coffee.node_data $el, d
     else if n_key == d_key
       maybe_do_update $nodes[i], d
     else
       if !nodes_to_keep[n_key]
-        exit $n
+        if exit?
+          exit $n, singult.coffee.node_data
+        $container.removeChild $n
 
       if nodes_to_keep[d_key]
         $el = nodes_to_keep[d_key]
@@ -293,7 +294,10 @@ singult.coffee.unify_ = ($container, u) ->
   # if we've run out of d, kill everything else
   data_len = u.data.length
   while data_len < $nodes.length
-    exit $nodes[data_len]
+    $n = $nodes[data_len];
+    if exit?
+      exit $n, singult.coffee.node_data $n
+    $container.removeChild $n
 
   return null
 


### PR DESCRIPTION
- 'enter' is called when a datum is added the first time.
  Given a datum, it should return a dom node that will be appended/inserted in the appropriate place.
  Previously enter was expected to insert/append the node manually, but was not passed the container.
  This is consistent with the behaviour of render's enter.
- 'exit' is called when a datum is removed (actual remove, not just update).
  Given the dom node and the datum, exit may clean up any structures created by enter/update but is
  not required to do anything at all. After exit returns the dom node will be removed from its container.
  Previously exit was expected to remove the dom node but was not provided with the datum. Relaxing the
  requirement that exit remove the node is more symmetric with enter's behaviour.

I want to use enter/exit to attach/detach event handlers to the dom. Currently I can't specify a custom enter fn because I don't have access to the parent element to attach the node to.

I believe that these changes don't affect existing code as dom inserts/removes are idempotent and the extra argument to exit will be safely ignored by existing code, but you might want to verify that for yourself. Happy to change/discuss this patch. 
